### PR TITLE
Fix CLI dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "redoc-cli": "^0.9.6",
     "remote-origin-url": "^2.0.0",
     "shelljs": "^0.7.0",
-    "swagger-repo": "2.0.0-rc.15",
+    "@redocly/openapi-cli": "0.8.4",
     "swagger-ui-dist": "3.24.0",
     "update-notifier": "3.0.1",
     "yargs-parser": "15.0.0"
@@ -24,8 +24,6 @@
   "bin": "./dist/gh-openapi-docs.js",
   "scripts": {
     "fetch": "node src/fetchpages.js",
-    "swagger": "swagger-repo",
-    "redoc": "redoc-cli",
     "build:swagger": "node src/swagger-ui.js",
     "build:redoc": "node src/redoc-ui.js",
     "clean": "rm -rf dist/* bin/*",

--- a/src/lib/bundle.js
+++ b/src/lib/bundle.js
@@ -34,10 +34,10 @@ const bundleSpec = async () => {
         'text': OPENAPI_JSON_PATH
     });
     shell.exec(
-        `npm run swagger bundle --        -b ${specDir} -o ${OPENAPI_JSON_PATH}`
+        `openapi bundle -f --output ${OPENAPI_JSON_PATH} ${config.apiSpecPath}`
     );
     shell.exec(
-        `npm run swagger bundle -- --yaml -b ${specDir} -o ${OPENAPI_YAML_PATH}`
+        `openapi bundle -f --output ${OPENAPI_YAML_PATH} ${config.apiSpecPath}`
     );
     shell.rm('-rf', specDir);
 };

--- a/src/lib/redoc-ui.js
+++ b/src/lib/redoc-ui.js
@@ -14,7 +14,7 @@ const setupUI = () => {
     var indexPath = path.join(uiPath, 'index.html');
     log.log(`Generating OpenAPI docs index at '${indexPath}'`);
     shell.exec(
-        `npm run redoc bundle -- ${OPENAPI_YAML_PATH} --output ${indexPath}`
+        `redoc-cli bundle --output ${indexPath} ${OPENAPI_YAML_PATH}`
     );
     log.preview({
         'title': 'OpenAPI docs folder contents',


### PR DESCRIPTION
This PR swaps the (seemingly) deprecated **swagger-repo** dependency with **@redocly/openapi-cli** and also corrects usage of globally installed CLIs (**openapi** and **redoc-cli**) in respective modules.