### PR TITLE
Fix CLI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 ## Installation
 
-After cloning this repo...
+Install command-line dependencies:
 
 ```shell
-npm i && npm install -g swagger-repo && npm install -g redoc-cli
-npm run cleanBuildPackage
+npm install -g @redocly/openapi-cli && npm install -g redoc-cli
+```
+
+Install CLI:
+
+```shell
+npm install -g gh-openapi-docs
 ```
 
 ## Set up
@@ -37,7 +42,7 @@ Where `branchPath` is the repo root if the current branch is `master`, otherwise
 Run the command...
 
 ```shell
-./bin/gh-openapi-docs
+gh-openapi-docs
 ```
 
 You should see console logs that look like this:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "yargs-parser": "15.0.0"
   },
   "bin": "./dist/bundle.js",
+  "main": "./src/lib/index.js",
   "scripts": {
     "fetch": "node src/fetchpages.js",
     "build:swagger": "node src/swagger-ui.js",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "build:redoc": "node src/redoc-ui.js",
     "clean": "rm -rf dist/* bin/*",
     "build": "npx webpack --mode=development",
-    "package": "npx pkg -o ./bin/gh-openapi-docs .",
     "cleanBuild": "npm run clean && npm run build",
-    "cleanBuildPackage": "npm run cleanBuild && npm run package",
-    "prepublish": "npm run cleanBuildPackage"
+    "prepublish": "npm run cleanBuild"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
@@ -40,7 +38,6 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
     "babel-loader": "^8.0.6",
-    "pkg": "^4.4.4",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.10"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-notifier": "3.0.1",
     "yargs-parser": "15.0.0"
   },
-  "bin": "./dist/gh-openapi-docs.js",
+  "bin": "./dist/bundle.js",
   "scripts": {
     "fetch": "node src/fetchpages.js",
     "build:swagger": "node src/swagger-ui.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
         'gh-openapi-docs': './src/gh-openapi-docs.js'
     },
     output: {
-        path: path.resolve(__dirname, 'dist')
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'bundle.js'
     },
     resolve: {
         modules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
     target: "node",
@@ -33,5 +34,8 @@ module.exports = {
                 }
             }
         ]
-    }
+    },
+    plugins: [
+        new webpack.BannerPlugin({ banner: "#!/usr/bin/env node", raw: true })
+    ]
 }


### PR DESCRIPTION
At least based on local testing (i.e., `npm install -g <folder>` from a different directory), these changes result in the CLI working as expected. Still need to check whether publishing to npm works (#12).