### PR TITLE
Fix branch envvar

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:swagger": "node src/swagger-ui.js",
     "build:redoc": "node src/redoc-ui.js",
     "clean": "rm -rf dist/* bin/*",
-    "build": "npx webpack --mode=development",
+    "build": "npx webpack-cli --mode=development",
     "cleanBuild": "npm run clean && npm run build"
   },
   "devDependencies": {

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -4,6 +4,7 @@ import getRepoInfo from 'git-repo-info';
 /*eslint no-process-env:0*/
 
 var repoInfo = getRepoInfo();
+console.log(repoInfo);
 
 const env = process.env.NODE_ENV;
 const repoOrigin = origin.sync();

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -4,6 +4,7 @@ import getRepoInfo from 'git-repo-info';
 /*eslint no-process-env:0*/
 
 var repoInfo = getRepoInfo();
+repoInfo.branch = repoInfo.branch || process.env.TRAVIS_BRANCH;
 console.log(repoInfo);
 
 const env = process.env.NODE_ENV;


### PR DESCRIPTION
If the value for `branch` (returned from `getRepoInfo()` via the `git-repo-info` library) is `null`, use the environment variable `$TRAVIS_BRANCH` instead.