### PR TITLE
publish to @ga4gh/gh-openapi-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gh-openapi-docs",
+  "name": "@ga4gh/gh-openapi-docs",
   "author": "James Eddy <james.a.eddy@gmail.com>",
   "version": "0.2.1",
   "license": "Apache-2.0",
@@ -59,5 +59,8 @@
   "nyc": {
     "instrument": false,
     "sourceMap": false
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
`package.json` has been modified to include the `@ga4gh` org scope, as well as a config to indicate the package is public.

for npm users with write access, the package can be published via command line by first logging in and then publishing. ie:
`npm login`
`npm publish`

the package is published at: [https://www.npmjs.com/package/@ga4gh/gh-openapi-docs](https://www.npmjs.com/package/@ga4gh/gh-openapi-docs)