### PR TITLE
Hotfix 43 fix undefined branch

### DIFF
--- a/src/gh-openapi-docs.js
+++ b/src/gh-openapi-docs.js
@@ -1,7 +1,7 @@
 import '@babel/polyfill';
 // const updater = require('update-notifier');
 import parseArgs from 'yargs-parser';
-import pkg from '../package.json';
+// import pkg from '../package.json';
 import release from './lib';
 
 const aliases = {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { merge } from 'lodash';
 import path from 'path';
 import envConfig from './environment'
 import fs from 'fs';
@@ -37,7 +37,7 @@ const deployConfig = {
 };
 // Export the config object based on the NODE_ENV
 // ==============================================
-const config = _.merge(
+const config = merge(
   localConfig,
   envConfig,
   deployConfig

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -1,14 +1,14 @@
-import _ from 'lodash';
+import { merge } from 'lodash';
 import origin from 'remote-origin-url';
 import getRepoInfo from 'git-repo-info';
 /*eslint no-process-env:0*/
 
 var repoInfo = getRepoInfo();
-repoInfo.branch = repoInfo.branch || process.env.TRAVIS_BRANCH;
+repoInfo.branch = repoInfo.branch || process.env.TRAVIS_BRANCH || "undefined";
 
 const env = process.env.NODE_ENV;
 const repoOrigin = origin.sync();
-const environment = _.merge(repoInfo, {
+const environment = merge(repoInfo, {
     env,
     repoOrigin
 });

--- a/src/lib/tasks.js
+++ b/src/lib/tasks.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Logger from './log';
 import Config from './config';
 import { fetchPages } from './gh-pages';


### PR DESCRIPTION
This PR aims to fix #43.

Currently, running `gh-openapi-docs` in a GH Action on `pull_request` leads `gh-openapi-docs` to determine that the current branch is `undefined`. I guess that this is because in PR, GH creates a temporary branch where it merges the content of the target branch and the branch that contains the changes listed in the PR. This leads the npm package `git-repo-info` to return `getRepoInfo().branch` as `undefined`. `gh-openapi-docs` fails when attempting to run `undefined`.toLowerCase().

Proposed solution implemented in this PR: Set the value of `repoInfo.branch()` later used by `gh-openapi-docs` to the string "undefined". This will fix the issue and the documentation will be exported to `preview/undefined/{openapi.json,openapi.yaml,docs}`.