### PR TITLE
Replace ./ import by @lib/ using Babel resolver

### DIFF
--- a/src/lib/bundle.js
+++ b/src/lib/bundle.js
@@ -2,8 +2,8 @@
 'use strict';
 import shell from "shelljs";
 import path from 'path';
-import config from './config';
-import Log from './log';
+import config from '@lib/config';
+import Log from '@lib/log';
 
 const log = new Log();
 

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -1,5 +1,5 @@
 import pkg from '../../package.json';
-import Log from './log';
+import Log from '@lib/log';
 
 const log = new Log();
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 import path from 'path';
-import envConfig from './environment'
+import envConfig from '@lib/environment'
 import fs from 'fs';
 /*eslint no-process-env:0*/
 

--- a/src/lib/gh-pages.js
+++ b/src/lib/gh-pages.js
@@ -1,7 +1,7 @@
 'use strict';
 import shell from 'shelljs';
-import config from './config';
-import Log from './log';
+import config from '@lib/config';
+import Log from '@lib/log';
 import fs from 'fs';
 
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,5 @@
-import { version, help } from './cli';
-import runTasks from './tasks';
+import { version, help } from '@lib/cli';
+import runTasks from '@lib/tasks';
 
 const release = async options =>  {
   if (options.version) {

--- a/src/lib/redoc-ui.js
+++ b/src/lib/redoc-ui.js
@@ -2,9 +2,9 @@
 'use strict';
 import shell from 'shelljs';
 import path from 'path';
-import config from './config';
-import themes from './theme';
-import Log from './log';
+import config from '@lib/config';
+import themes from '@lib/theme';
+import Log from '@lib/log';
 
 const log = new Log();
 var OPENAPI_YAML_PATH = path.join(config.branchPath, 'openapi.yaml');

--- a/src/lib/swagger-ui.js
+++ b/src/lib/swagger-ui.js
@@ -2,8 +2,8 @@
 'use strict';
 import shell from 'shelljs';
 import path from 'path';
-import config from './config';
-import Log from './log';
+import config from '@lib/config';
+import Log from '@lib/log';
 
 const log = new Log();
 

--- a/src/lib/tasks.js
+++ b/src/lib/tasks.js
@@ -1,8 +1,8 @@
-import Logger from './log';
-import Config from './config';
-import { fetchPages } from './gh-pages';
-import bundleSpec from './bundle';
-import { setupUI } from './redoc-ui';
+import Logger from '@lib/log';
+import Config from '@lib/config';
+import { fetchPages } from '@lib/gh-pages';
+import bundleSpec from '@lib/bundle';
+import { setupUI } from '@lib/redoc-ui';
 
 const runTasks = (opts, di) => {
   let container = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,8 @@ module.exports = {
         alias: {
             '@lib': path.resolve(__dirname, 'src/lib')
         },
-        modules: [
-            'node_modules'
-        ]
+        extensions: ['.js'],
+        modules: ['node_modules']
     },
     module: {
         rules: [


### PR DESCRIPTION
This PR aims to fix #27.

This PR replaces all relative import by absolute imports using `@lib/`.

`npm run build` and `npm run test` completes successfully.