### PR TITLE
Run local install of openapi and redoc-cli

### DIFF
--- a/src/lib/bundle.js
+++ b/src/lib/bundle.js
@@ -34,11 +34,11 @@ const bundleSpec = async () => {
         'text': `${config.branchPath}/\n`
     });
     shell.exec(
-        `openapi bundle -f --output ${OPENAPI_JSON_PATH} ${config.apiSpecPath}`,
+        `npx openapi bundle -f --output ${OPENAPI_JSON_PATH} ${config.apiSpecPath}`,
         {silent: true}
     );
     shell.exec(
-        `openapi bundle -f --output ${OPENAPI_YAML_PATH} ${config.apiSpecPath}`,
+        `npx openapi bundle -f --output ${OPENAPI_YAML_PATH} ${config.apiSpecPath}`,
         {silent: true}
     );
     shell.rm('-rf', specDir);

--- a/src/lib/redoc-ui.js
+++ b/src/lib/redoc-ui.js
@@ -28,7 +28,7 @@ const setupUI = () => {
         text: `${indexPath}\n`
     });
     shell.exec(
-        `redoc-cli bundle --output ${indexPath} ${OPENAPI_YAML_PATH} ${redocOpts}`,
+        `npx redoc-cli bundle --output ${indexPath} ${OPENAPI_YAML_PATH} ${redocOpts}`,
         {silent: true}
     );
 };


### PR DESCRIPTION
The existing implementation requires the user to install `@redocly/openapi-cli` and `redoc-cli` globally. This is not a good practice because running this tool should not require the user to do modifications to his/her development environment that could have side effect on other of his/her project. Instead, this PR proposes that the scripts *bundle.js* and *redoc-ui.js* executes locally-installed `openapi` and `redoc-cli`.