### PR TITLE
Fix GH workflow that builds package for npmjs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         node-version: ${{ env.node_version }}
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
+    - run: npm run build
     - run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I noticed that the *dist/bundle.js* was missing from [this npmjs package](https://www.npmjs.com/package/gh-openapi-docs-ts) that I build from my fork of this project. The reason is because I forgot to include the instruction `npm run build` in the GH workflow now used in this project.