### PR TITLE
specify output directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,6 @@ RUN npm install -g pkg
 RUN npm install -g @redocly/openapi-cli
 RUN pkg `which openapi` -o openapi
 
-# CREATE BINARY FOR REDOC CLI
-# RUN npm install -g redoc-cli
-# RUN echo "HELLO FOO"
-# RUN which redoc-cli
-# RUN find / -name redoc.standalone.js
-# RUN pkg `which redoc-cli` -o redoc-cli
-
 # CREATE BINARY FOR GH OPENAPI DOCS
 COPY package.json package.json
 COPY package-lock.json package-lock.json
@@ -33,16 +26,12 @@ RUN pkg dist/bundle.js -o gh-openapi-docs
 # FINAL IMAGE
 # ########################################
 
-# FROM alpine:3.15
 FROM node:16.13.2-alpine3.14
 
 WORKDIR /usr/local/bin
 
 COPY --from=builder /usr/src/build/openapi openapi
 COPY --from=builder /usr/src/build/gh-openapi-docs gh-openapi-docs
-
-# COPY --from=builder /usr/local/bin/redoc-cli redoc-cli
-# COPY --from=builder /usr/local/lib/node_modules/redoc-cli /usr/local/lib/node_modules/redoc-cli
 
 RUN npm install -g redoc-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ RUN npm install -g @redocly/openapi-cli
 RUN pkg `which openapi` -o openapi
 
 # CREATE BINARY FOR REDOC CLI
-RUN npm install -g redoc-cli
-RUN pkg `which redoc-cli` -o redoc-cli
+# RUN npm install -g redoc-cli
+# RUN echo "HELLO FOO"
+# RUN which redoc-cli
+# RUN find / -name redoc.standalone.js
+# RUN pkg `which redoc-cli` -o redoc-cli
 
 # CREATE BINARY FOR GH OPENAPI DOCS
 COPY package.json package.json
@@ -30,16 +33,26 @@ RUN pkg dist/bundle.js -o gh-openapi-docs
 # FINAL IMAGE
 # ########################################
 
-FROM alpine:3.15
+# FROM alpine:3.15
+FROM node:16.13.2-alpine3.14
 
-WORKDIR /usr/bin
+WORKDIR /usr/local/bin
 
 COPY --from=builder /usr/src/build/openapi openapi
-COPY --from=builder /usr/src/build/redoc-cli redoc-cli
 COPY --from=builder /usr/src/build/gh-openapi-docs gh-openapi-docs
+
+# COPY --from=builder /usr/local/bin/redoc-cli redoc-cli
+# COPY --from=builder /usr/local/lib/node_modules/redoc-cli /usr/local/lib/node_modules/redoc-cli
+
+RUN npm install -g redoc-cli
 
 RUN apk add git
 
 WORKDIR /docs
+
+RUN which openapi
+RUN which redoc-cli
+RUN which gh-openapi-docs
+RUN ls -la /usr/local/lib/node_modules/redoc-cli/node_modules/redoc/bundles/redoc.standalone.js
 
 ENTRYPOINT [ "gh-openapi-docs" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,44 @@
-FROM node:14.17.4-alpine3.14
+# ########################################
+# BUILDER IMAGE
+# ########################################
+
+FROM node:16.13.2-alpine3.14 as builder
+
+WORKDIR /usr/src/build
+
+RUN npm install -g pkg
+
+# CREATE BINARY FOR OPENAPI
+RUN npm install -g @redocly/openapi-cli
+RUN pkg `which openapi` -o openapi
+
+# CREATE BINARY FOR REDOC CLI
+RUN npm install -g redoc-cli
+RUN pkg `which redoc-cli` -o redoc-cli
+
+# CREATE BINARY FOR GH OPENAPI DOCS
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+COPY src src
+COPY webpack.config.js webpack.config.js
+
+RUN npm install
+RUN npm run build
+RUN pkg dist/bundle.js -o gh-openapi-docs
+
+# ########################################
+# FINAL IMAGE
+# ########################################
+
+FROM alpine:3.15
+
+WORKDIR /usr/bin
+
+COPY --from=builder /usr/src/build/openapi openapi
+COPY --from=builder /usr/src/build/redoc-cli redoc-cli
+COPY --from=builder /usr/src/build/gh-openapi-docs gh-openapi-docs
 
 RUN apk add git
-
-RUN npm install -g @redocly/openapi-cli
-RUN npm install -g redoc-cli
-RUN npm install -g @ga4gh/gh-openapi-docs@0.2.2-rc3
 
 WORKDIR /docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14.17.4-alpine3.14
+
+RUN apk add git
+
+RUN npm install -g @redocly/openapi-cli
+RUN npm install -g redoc-cli
+RUN npm install -g @ga4gh/gh-openapi-docs@0.2.2-rc3
+
+WORKDIR /docs
+
+ENTRYPOINT [ "gh-openapi-docs" ]

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ Nothing:
 .PHONY: docker-build
 docker-build:
 	@docker build -t ga4gh/gh-openapi-docs:${VERSION} .
+
+.PHONY: docker-publish
+docker-publish:
+	@docker push ga4gh/gh-openapi-docs:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+VERSION := $(shell cat package.json | grep version | rev | cut -f 1 -d ' ' | rev | tr -d '"' | tr -d ',')
+
+Nothing:
+	@echo "No target provided. Stop."
+
+.PHONY: docker-build
+docker-build:
+	@docker build -t ga4gh/gh-openapi-docs:${VERSION} .

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ga4gh/gh-openapi-docs",
   "description": "Build ReDoc API documentation for an OpenAPI specification and host on GitHub Pages",
   "author": "James Eddy <james.a.eddy@gmail.com>",
-  "version": "2022-01-17-SNAPSHOT",
+  "version": "0.2.3-rc1",
   "license": "Apache-2.0",
   "repository": "github:ga4gh/gh-openapi-docs",
   "main": "./src/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ga4gh/gh-openapi-docs",
   "description": "Build ReDoc API documentation for an OpenAPI specification and host on GitHub Pages",
   "author": "James Eddy <james.a.eddy@gmail.com>",
-  "version": "0.2.2-rc3",
+  "version": "2022-01-17-SNAPSHOT",
   "license": "Apache-2.0",
   "repository": "github:ga4gh/gh-openapi-docs",
   "main": "./src/lib/index.js",

--- a/src/lib/bundle.js
+++ b/src/lib/bundle.js
@@ -33,12 +33,12 @@ const bundleSpec = async buildPage => {
         'text': `${config.branchPath}/\n`
     });
     shell.exec(
-        `npx openapi bundle -f --output ${openApiJsonPath} ${specPath}`,
-        {silent: true}
+        `openapi bundle -f --output ${openApiJsonPath} ${specPath}`,
+        {silent: false}
     );
     shell.exec(
-        `npx openapi bundle -f --output ${openApiYamlPath} ${specPath}`,
-        {silent: true}
+        `openapi bundle -f --output ${openApiYamlPath} ${specPath}`,
+        {silent: false}
     );
     shell.rm('-rf', specDir);
 };

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -7,6 +7,7 @@ program.version(pkg.version);
 program
   .option('-c --config <config>', `Path to local configuration options [default: ".spec-docs.json"]`, ".spec-docs.json")
   .option('-d --dry-run [bool]', `Do not touch or write anything, but show the commands`, false)
+  .option('-o --output-dir <output_dir>', `Output directory containing built docs added to the current checkout of 'gh-pages'`, "publish")
   .option('-v --verbose [bool]', `Verbose output`, false);
 program.parse(process.argv)
 let cliOpts = program.opts();

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -25,14 +25,15 @@ const localConfig = {
       'yamlOutfile': 'openapi.yaml',
       'jsonOutfile': 'openapi.json'
     }
-  ]
+  ],
+  outputDir: cliOpts.outputDir || 'publish'
 };
 
-const constructBranchPath = (defaultBranch, currentBranch, root, branchPathBase) => {
+const constructBranchPath = (defaultBranch, currentBranch, root, outputDir, branchPathBase) => {
   if (currentBranch == defaultBranch) {
-    return root;
+    return path.join(root, outputDir);
   } else {
-    return path.join(root, branchPathBase, currentBranch.toLowerCase())
+    return path.join(root, outputDir, branchPathBase, currentBranch.toLowerCase())
   }
 };
 
@@ -41,6 +42,7 @@ const deployConfig = {
     localConfig.defaultBranch,
     envConfig.branch,
     envConfig.root,
+    localConfig.outputDir,
     localConfig.branchPathBase
   )
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -36,12 +36,13 @@ const constructBranchPath = (workingDir, outputDir, branchPathBase, currentBranc
 
 const deployConfig = {
   branchPath: constructBranchPath(
-    localConfig.pwd,
+    localConfig.workingDir,
     localConfig.outputDir,
     localConfig.branchPathBase,
     envConfig.branch
   )
 };
+
 // Export the config object based on the NODE_ENV
 // ==============================================
 const config = merge(

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -26,24 +26,20 @@ const localConfig = {
       'jsonOutfile': 'openapi.json'
     }
   ],
+  workingDir: process.env.PWD,
   outputDir: cliOpts.outputDir || 'publish'
 };
 
-const constructBranchPath = (defaultBranch, currentBranch, root, outputDir, branchPathBase) => {
-  if (currentBranch == defaultBranch) {
-    return path.join(root, outputDir);
-  } else {
-    return path.join(root, outputDir, branchPathBase, currentBranch.toLowerCase())
-  }
+const constructBranchPath = (workingDir, outputDir, branchPathBase, currentBranch) => {
+  return path.join(workingDir, outputDir, branchPathBase, currentBranch.toLowerCase())
 };
 
 const deployConfig = {
   branchPath: constructBranchPath(
-    localConfig.defaultBranch,
-    envConfig.branch,
-    envConfig.root,
+    localConfig.pwd,
     localConfig.outputDir,
-    localConfig.branchPathBase
+    localConfig.branchPathBase,
+    envConfig.branch
   )
 };
 // Export the config object based on the NODE_ENV

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -26,7 +26,7 @@ const localConfig = {
       'jsonOutfile': 'openapi.json'
     }
   ],
-  workingDir: process.env.PWD,
+  workingDir: process.cwd(), // process.env.PWD,
   outputDir: cliOpts.outputDir || 'publish'
 };
 

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -4,7 +4,7 @@ import getRepoInfo from 'git-repo-info';
 /*eslint no-process-env:0*/
 
 var repoInfo = getRepoInfo();
-repoInfo.branch = repoInfo.branch || process.env.TRAVIS_BRANCH || "undefined";
+repoInfo.branch = repoInfo.branch || process.env.GITHUB_HEAD_REF || process.env.TRAVIS_BRANCH || "undefined";
 
 const env = process.env.NODE_ENV;
 const repoOrigin = origin.sync();

--- a/src/lib/gh-pages.js
+++ b/src/lib/gh-pages.js
@@ -8,22 +8,15 @@ import fs from 'fs';
 const log = new Log();
 
 const fetchPages = () => {
-    shell.rm('-rf', '.ghpages-tmp');
-    shell.mkdir('-p', '.ghpages-tmp');
+    shell.rm('-rf', config.outputDir);
+    shell.mkdir('-p', config.outputDir);
     var startDir = shell.pwd();
-    shell.cd('.ghpages-tmp');
-    log.log(`\nCloning 'gh-pages' branch into '${shell.pwd().stdout}'`);
+    shell.cd(config.outputDir);
+    log.log(`\nCloning 'gh-pages' branch into '${config.outputDir}'`);
     shell.exec(
         `git clone --depth=1 --branch=gh-pages ${config.repoOrigin} .`,
         {silent: true}
     );
-    shell.cp('-Rn', config.branchPathBase, config.root);
-    if (fs.existsSync(config.docsRoot)) {
-        shell.cp('-Rn', config.docsRoot, config.root);
-        shell.cp('-Rn', 'openapi.*', config.root);
-    }
-    shell.cd(startDir);
-    shell.rm('-rf', '.ghpages-tmp')
 };
 
 export { fetchPages };

--- a/src/lib/redoc-ui.js
+++ b/src/lib/redoc-ui.js
@@ -29,8 +29,8 @@ const setupUI = buildPage => {
     });
     
     shell.exec(
-        `npx redoc-cli bundle --output ${indexPath} ${openApiYamlPath} ${redocOpts}`,
-        {silent: true}
+        `redoc-cli bundle --output ${indexPath} ${openApiYamlPath} ${redocOpts}`,
+        {silent: false}
     );
 };
 


### PR DESCRIPTION
Output directory is now `$PWD/publish` rather than the current working directory. Having a distinct publishing directory (i.e. what will be pushed to `gh-pages`), integrates better with existing [tools on Github Actions](https://github.com/marketplace/actions/deploy-to-github-pages), compared to building the docs in the current working directory.

It is possible to override the default value of `publish` with `-o`